### PR TITLE
Refacto follow-up (fixups)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@ Configuration can be overwritten in `config.json`:
 {
   "Host": "0.0.0.0",
   "Port": "7000",
-  "Authentication": {
-    "User": "SonarSource",
-    "Password": "number1"
-  }
+  "User": "SonarSource",
+  "Password": "number1"
 }
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod middleware;
 
 use actix_web::http::Method;
 use actix_web::{server, App};
+use actix_web::middleware::Logger;
 
 fn main() {
     simple_logger::init_with_level(log::Level::Info).unwrap();
@@ -26,12 +27,13 @@ fn main() {
     let address = conf::get_address(&configuration);
     server::new(move ||
         App::new()
-            .middleware(middleware::ResponseTime::default())
+            .middleware(Logger::default())
             .middleware(middleware::Authentication::new(&configuration))
             .resource("/", |r| r.method(Method::GET).f(handlers::welcome))
             .resource("/ping", |r| r.method(Method::GET).f(handlers::ping))
             .resource("/download", |r| r.method(Method::GET).with(handlers::download))
             .resource("/upload", |r| r.method(Method::POST).with(handlers::upload))
+            .resource("/exec", |r| r.method(Method::POST).with(handlers::execute))
     ).bind(address)
         .unwrap()
         .run();

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,50 +1,20 @@
 use http::header;
 use actix_web::{http, error, HttpRequest, HttpResponse, Result};
 use actix_web::middleware::{Middleware, Started, Response};
-use std::time::Instant;
 use crate::conf::Configuration;
 use base64;
-use std::str;
-
-pub struct ResponseTime {}
-
-impl<S> Middleware<S> for ResponseTime {
-    fn start(&self, req: &HttpRequest<S>) -> Result<Started> {
-        req.request().extensions_mut().insert(Instant::now());
-        Ok(Started::Done)
-    }
-
-    fn response(&self, req: &HttpRequest<S>, resp: HttpResponse)
-                -> Result<Response> {
-        req.request().extensions().get::<Instant>()
-            .map(|instant| info!("Elapsed time on {} for {}, : {} ms", req.path(), req.connection_info().remote().unwrap_or_else(|| "unknown"), instant.elapsed().as_millis()));
-        Ok(Response::Done(resp))
-    }
-}
-
-impl Default for ResponseTime {
-    fn default() -> Self {
-        ResponseTime {}
-    }
-}
 
 pub struct Authentication {
-    username: String,
-    password: String
+    token: String
 }
 
 impl<S> Middleware<S> for Authentication {
     fn start(&self, req: &HttpRequest<S>) -> Result<Started> {
-        // don't validate CORS pre-flight requests
-        if req.method() == "OPTIONS" {
-            return Ok(Started::Done);
-        }
-
-        let (username, password) = req.headers().get(header::HeaderName::from_static("authorization"))
+        let token = req.headers().get(header::HeaderName::from_static("authorization"))
             .ok_or(error::ErrorUnauthorized(format_err!("Missing authorization header")))
             .and_then(|header_value| parse(header_value).map_err(|e| error::ErrorUnauthorized(e)))?;
 
-        if username == self.username && password == self.password {
+        if token == self.token {
             Ok(Started::Done)
         } else {
             Err(error::ErrorForbidden(format_err!("Invalid username/password")))
@@ -57,30 +27,19 @@ impl<S> Middleware<S> for Authentication {
     }
 }
 
-fn parse(header: &header::HeaderValue) -> Result<(String, String), failure::Error> {
+fn parse(header: &header::HeaderValue) -> Result<String, failure::Error> {
     let mut parts = header.to_str()?.splitn(2, ' ');
     match parts.next() {
         Some(scheme) if scheme == "Basic" => (),
         _ => return Err(format_err!("Invalid header : No basic authentication")),
     }
-    let encoded = parts.next().ok_or(format_err!("Invalid basic header : No encoded part"))?;
-    let decoded = base64::decode(encoded)?;
-    let mut credentials = str::from_utf8(&decoded)?
-        .splitn(2, ':');
-    let username = credentials.next()
-        .ok_or(format_err!("Invalid basic header : No username"))
-        .map(|username| username.to_string())?;
-    let password = credentials.next()
-        .ok_or(format_err!("Invalid basic header : No password"))
-        .map(|password| password.to_string())?;
-    Ok((username, password))
+    parts.next().map(|str| String::from(str)).ok_or(format_err!("Invalid basic header : No token"))
 }
 
 impl Authentication {
     pub fn new(configuration: &Configuration) -> Self {
         Authentication{
-            username: configuration.user.clone(),
-            password: configuration.password.clone()
+            token: base64::encode(&format!("{}:{}", configuration.user, configuration.password))
         }
     }
 }


### PR DESCRIPTION
feat: Add missing exec handler
refacto: Remove ResponseTime middleware for default actix-web Logger (more informations)
refacto: Change Authentication middleware to match directly token instead of base64 decoding at each request
docs: Fix example config in README.md